### PR TITLE
Reverse-engineer some required missed stuff (not implemented)

### DIFF
--- a/ivp_controller/ivp_actuator.hxx
+++ b/ivp_controller/ivp_actuator.hxx
@@ -348,6 +348,7 @@ protected:
     // To create a new force actuator, use the method IVP_Environment->create_force
     IVP_Actuator_Force(IVP_Environment *env, IVP_Template_Force *templ);
 public:
+    IVP_DOUBLE get_force() const { return force; }
     void set_force(IVP_DOUBLE new_force);
     virtual ~IVP_Actuator_Force();
 

--- a/ivp_intern/ivp_environment.cxx
+++ b/ivp_intern/ivp_environment.cxx
@@ -513,20 +513,12 @@ void IVP_Environment::delete_draw_vector_debug(){
 
 void IVP_Environment::force_psi_on_next_simulation()
 {
-    /*IVP_Time_Manager* v2; // esi
-    double v3; // ST0C_8
-    unsigned int* v4; // edi
-    long double v5; // xmm0_8
+    double now_seconds = current_time.get_seconds();
+    IVP_Time_Event_PSI *last_event = time_manager->psi_event;
+    double diff_seconds = now_seconds - time_manager->base_time.get_seconds();
 
-    v2 = this->time_manager;
-    LODWORD(v3) = LODWORD(this->current_time.get_seconds());
-    v4 = (unsigned int*)v2->psi_event;
-    HIDWORD(v3) = HIDWORD(this->current_time.get_seconds());
-    v5 = v3 - time_manager->base_time.get_seconds();
-    time_manager->min_hash->remove_minlist_elem(v4[1]);
-    v4[1] = time_manager->min_hash->add(v4, v5);*/
-
-    IVP_ASSERT(0 && "Unimplemented");
+    time_manager->min_hash->remove_minlist_elem(last_event->index);
+    last_event->index = time_manager->min_hash->add(last_event, diff_seconds);
 }
 
 IVP_Polygon *IVP_Environment::create_polygon(IVP_SurfaceManager *vic, const IVP_Template_Real_Object *templ,


### PR DESCRIPTION
* Unable to get into jeep in tunnels due to not implemented `void IVP_Car_System_Real_Wheels::set_powerslide(IVP_FLOAT front_accel, IVP_FLOAT rear_accel)`. Now should be ok. Forces which are set here not used anyway :(

* Reverse `IVP_Environment::force_psi_on_next_simulation`. Not used anyway, but for full picture. 

