### PR TITLE
hkmath,ivp_intern: CPU cache friendly iteration over potentially large arrays

### DIFF
--- a/havana/havok/hk_math/vector_fpu/vector_fpu.inl
+++ b/havana/havok/hk_math/vector_fpu/vector_fpu.inl
@@ -122,7 +122,7 @@ inline hk_real hk_VecFPU::fpu_large_dot_product(hk_real *base_a, hk_real *base_b
 	return result_sum;
     } else {
 	hk_real sum=0.0f;
-	for(int i=size-1;i>=0;i--) {
+	for(int i=0;i<size;i++) {
 	    sum += base_a[i] * base_b[i];
 	}
 	return sum;
@@ -421,7 +421,7 @@ inline hk_double hk_VecFPU::fpu_large_dot_product(hk_double *base_a, hk_double *
 	return result_sum;
     } else {
 	hk_double sum=0.0;
-	for(int i=size-1;i>=0;i--) {
+	for(int i=0;i<size;i++) {
 	    sum += base_a[i] * base_b[i];
 	}
 	return sum;

--- a/ivp_intern/ivp_great_matrix.cxx
+++ b/ivp_intern/ivp_great_matrix.cxx
@@ -143,7 +143,7 @@ inline IVP_DOUBLE IVP_VecFPU::fpu_large_dot_product(IVP_DOUBLE *base_a, IVP_DOUB
 	return result_sum;
     } else {
 	IVP_DOUBLE sum=0.0f;
-	for(int i=size-1;i>=0;i--) {
+	for(int i=0;i<size;i++) {
 	    sum += base_a[i] * base_b[i];
 	}
 	return sum;


### PR DESCRIPTION
CPU precaches data in forward order.

Iterating over potentially large arrays in backward order causes additional cache line fills from memory.